### PR TITLE
#378 tensorflow 2.18.0 버전 requirements.txt반영

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,7 +5,8 @@ python-dotenv==1.0.1
 reflex==0.6.8
 scikit-learn==1.5.0
 supabase==2.4.3
-tensorflow==2.15.0
+tensorflow==2.18.0; sys_platform != "darwin" or platform_machine == "arm64"
+tensorflow==2.16.2; sys_platform == "darwin" and platform_machine == "x86_64"
 torch==2.2.2
 torchaudio==2.2.2
 torchvision==0.17.2
@@ -17,3 +18,4 @@ reflex-wordcloud==0.0.4
 psycopg2-binary==2.9.9
 faiss-cpu==1.9.0.post1
 pandas==2.2.3
+


### PR DESCRIPTION
- ubuntu버전은 이미 requirements_ubuntu.txt에서 반영
- macos intel(x86_64)는 2.17 이후로 tf 릴리즈 파일에서 빠지고 있어서 버전 따로 처리